### PR TITLE
pass preventDefault on to parent mouse event

### DIFF
--- a/elm-pep.js
+++ b/elm-pep.js
@@ -19,6 +19,9 @@ if (! ("PointerEvent" in window) ) {
 					pointerEvent.pointerId = 1
 					pointerEvent.isPrimary = true
 					elmPepTarget.dispatchEvent( pointerEvent )
+					if ( pointerEvent.defaultPrevented ) {
+						mouseEvent.preventDefault();
+					}
 				}
 			})
 		}


### PR DESCRIPTION
This fixes a bug for me with mpizenberg/elm-pointer-events, where despite setting `preventDefault` via `Pointer.onWithOptions`, mousedown-and-drag would result in text selection when dragging outside the element.

Presumably, something similar should be done for the (multiple) touch events? I haven't really played enough with that part to be sure whether a simple "or" of the various `defaultPrevented` flags would be the right condition.

Would something similar be needed for `stopPropagation`?

Please note that I'm not at all an authority on JS event handling.
