### PR TITLE
fix pointer events for Safari/iOS (fixes #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ properties specific to pointer events.
 [caniuse-pointer]: https://caniuse.com/#feat=pointer
 [jquery-pep]: https://github.com/jquery/PEP
 
-## Authors
+## Contributors
 
-* Matthieu Pizenberg: matthieu@pizenberg.fr
-* Thomas Forgione: thomas@tforgione.fr
+* Matthieu Pizenberg - @mpizenberg
+* Thomas Forgione - @tforgione
+* Robert Vollmert - @robx (iOS debugging)

--- a/elm-pep.js
+++ b/elm-pep.js
@@ -66,7 +66,18 @@ if (! ("PointerEvent" in window) ) {
 					}
 
 					pointerEvent.pointerId = 1 + touch.identifier
-					pointerEvent.isPrimary = (touch.identifier == 0)
+
+					// First touch is the primary pointer event.
+					if ( touchType === 'touchstart' && !elmPepTarget.hasPrimaryTouchId ) {
+						elmPepTarget.hasPrimaryTouchId = true
+						elmPepTarget.primaryTouchId = touch.identifier
+					}
+					pointerEvent.isPrimary = (touch.identifier === elmPepTarget.primaryTouchId)
+					if ( touchType === 'touchend' && pointerEvent.isPrimary ) {
+						elmPepTarget.hasPrimaryTouchId = false
+						elmPepTarget.primaryTouchId = null
+					}
+
 					elmPepTarget.dispatchEvent( pointerEvent )
 				}
 			}

--- a/elm-pep.js
+++ b/elm-pep.js
@@ -56,6 +56,15 @@ if (! ("PointerEvent" in window) ) {
 					mouseEvent.offsetY = touch.clientY - rect.top
 
 					let pointerEvent = new MouseEvent( pointerType, mouseEvent )
+
+					// Safari/iOS doesn't have movement{X,Y} but elm-mouse-events expects it
+					if ( ! pointerEvent.movementX ) {
+						pointerEvent.movementX = 0
+					}
+					if ( ! pointerEvent.movementY ) {
+						pointerEvent.movementY = 0
+					}
+
 					pointerEvent.pointerId = 1 + touch.identifier
 					pointerEvent.isPrimary = (touch.identifier == 0)
 					elmPepTarget.dispatchEvent( pointerEvent )

--- a/elm-pep.js
+++ b/elm-pep.js
@@ -2,6 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+// Variable to hold current primary touch event identifier.
+// iOS needs this since it does not attribute
+// identifier 0 to primary touch event.
+let primaryTouchId = null;
+
 if (!("PointerEvent" in window)) {
   // Create Pointer polyfill from mouse events only on non-touch device
   if (!("TouchEvent" in window)) {
@@ -57,15 +62,14 @@ if (!("PointerEvent" in window)) {
           pointerEvent.pointerId = 1 + touch.identifier;
 
           // First touch is the primary pointer event.
-          if (touchType === "touchstart" && !elmPepTarget.hasPrimaryTouchId) {
-            elmPepTarget.hasPrimaryTouchId = true;
-            elmPepTarget.primaryTouchId = touch.identifier;
+          if (touchType === "touchstart" && primaryTouchId === null) {
+            primaryTouchId = touch.identifier;
           }
-          pointerEvent.isPrimary =
-            touch.identifier === elmPepTarget.primaryTouchId;
+
+          // If first touch ends, reset primary touch id.
+          pointerEvent.isPrimary = touch.identifier === primaryTouchId;
           if (touchType === "touchend" && pointerEvent.isPrimary) {
-            elmPepTarget.hasPrimaryTouchId = false;
-            elmPepTarget.primaryTouchId = null;
+            primaryTouchId = null;
           }
 
           elmPepTarget.dispatchEvent(pointerEvent);

--- a/elm-pep.js
+++ b/elm-pep.js
@@ -2,83 +2,81 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+if (!("PointerEvent" in window)) {
+  // Create Pointer polyfill from mouse events only on non-touch device
+  if (!("TouchEvent" in window)) {
+    addMouseToPointerListener(document, "mousedown", "pointerdown");
+    addMouseToPointerListener(document, "mousemove", "pointermove");
+    addMouseToPointerListener(document, "mouseup", "pointerup");
 
-if (! ("PointerEvent" in window) ) {
+    function addMouseToPointerListener(target, mouseType, pointerType) {
+      target.addEventListener(mouseType, mouseEvent => {
+        const elmPepTarget = findElmPEP(mouseEvent.target);
+        if (elmPepTarget !== null) {
+          let pointerEvent = new MouseEvent(pointerType, mouseEvent);
+          pointerEvent.pointerId = 1;
+          pointerEvent.isPrimary = true;
+          elmPepTarget.dispatchEvent(pointerEvent);
+          if (pointerEvent.defaultPrevented) {
+            mouseEvent.preventDefault();
+          }
+        }
+      });
+    }
+  }
 
-	// Create Pointer polyfill from mouse events only on non-touch device
-	if (! ("TouchEvent" in window) ) {
-		addMouseToPointerListener( document, 'mousedown', 'pointerdown' )
-		addMouseToPointerListener( document, 'mousemove', 'pointermove' )
-		addMouseToPointerListener( document, 'mouseup', 'pointerup' )
+  addTouchToPointerListener(document, "touchstart", "pointerdown");
+  addTouchToPointerListener(document, "touchmove", "pointermove");
+  addTouchToPointerListener(document, "touchend", "pointerup");
 
-		function addMouseToPointerListener( target, mouseType, pointerType ) {
-			target.addEventListener( mouseType, ( mouseEvent ) => {
-				const elmPepTarget = findElmPEP( mouseEvent.target )
-				if ( elmPepTarget !== null ) {
-					let pointerEvent = new MouseEvent( pointerType, mouseEvent )
-					pointerEvent.pointerId = 1
-					pointerEvent.isPrimary = true
-					elmPepTarget.dispatchEvent( pointerEvent )
-					if ( pointerEvent.defaultPrevented ) {
-						mouseEvent.preventDefault();
-					}
-				}
-			})
-		}
-	}
+  function addTouchToPointerListener(target, touchType, pointerType) {
+    target.addEventListener(touchType, touchEvent => {
+      const elmPepTarget = findElmPEP(touchEvent.target);
+      if (elmPepTarget !== null) {
+        let mouseEvent = new CustomEvent("");
+        mouseEvent.ctrlKey = touchEvent.ctrlKey;
+        mouseEvent.shiftKey = touchEvent.shiftKey;
+        mouseEvent.altKey = touchEvent.altKey;
+        mouseEvent.metaKey = touchEvent.metaKey;
 
-	addTouchToPointerListener( document, 'touchstart', 'pointerdown' )
-	addTouchToPointerListener( document, 'touchmove', 'pointermove' )
-	addTouchToPointerListener( document, 'touchend', 'pointerup' )
+        const changedTouches = touchEvent.changedTouches;
+        const nbTouches = changedTouches.length;
+        for (let t = 0; t < nbTouches; t++) {
+          const touch = changedTouches.item(t);
+          mouseEvent.clientX = touch.clientX;
+          mouseEvent.clientY = touch.clientY;
+          mouseEvent.screenX = touch.screenX;
+          mouseEvent.screenY = touch.screenY;
+          mouseEvent.pageX = touch.pageX;
+          mouseEvent.pageY = touch.pageY;
+          const rect = touch.target.getBoundingClientRect();
+          mouseEvent.offsetX = touch.clientX - rect.left;
+          mouseEvent.offsetY = touch.clientY - rect.top;
 
-	function addTouchToPointerListener( target, touchType, pointerType ) {
-		target.addEventListener( touchType, ( touchEvent ) => {
-			const elmPepTarget = findElmPEP( touchEvent.target )
-			if ( elmPepTarget !== null ) {
-				let mouseEvent = new CustomEvent( '' )
-				mouseEvent.ctrlKey = touchEvent.ctrlKey
-				mouseEvent.shiftKey = touchEvent.shiftKey
-				mouseEvent.altKey = touchEvent.altKey
-				mouseEvent.metaKey = touchEvent.metaKey
+          let pointerEvent = new MouseEvent(pointerType, mouseEvent);
+          pointerEvent.pointerId = 1 + touch.identifier;
 
-				const changedTouches = touchEvent.changedTouches
-				const nbTouches = changedTouches.length
-				for ( let t=0; t < nbTouches; t++ ) {
-					const touch = changedTouches.item( t )
-					mouseEvent.clientX = touch.clientX
-					mouseEvent.clientY = touch.clientY
-					mouseEvent.screenX = touch.screenX
-					mouseEvent.screenY = touch.screenY
-					mouseEvent.pageX = touch.pageX
-					mouseEvent.pageY = touch.pageY
-					const rect = touch.target.getBoundingClientRect()
-					mouseEvent.offsetX = touch.clientX - rect.left
-					mouseEvent.offsetY = touch.clientY - rect.top
+          // First touch is the primary pointer event.
+          if (touchType === "touchstart" && !elmPepTarget.hasPrimaryTouchId) {
+            elmPepTarget.hasPrimaryTouchId = true;
+            elmPepTarget.primaryTouchId = touch.identifier;
+          }
+          pointerEvent.isPrimary =
+            touch.identifier === elmPepTarget.primaryTouchId;
+          if (touchType === "touchend" && pointerEvent.isPrimary) {
+            elmPepTarget.hasPrimaryTouchId = false;
+            elmPepTarget.primaryTouchId = null;
+          }
 
-					let pointerEvent = new MouseEvent( pointerType, mouseEvent )
-					pointerEvent.pointerId = 1 + touch.identifier
+          elmPepTarget.dispatchEvent(pointerEvent);
+        }
+      }
+    });
+  }
 
-					// First touch is the primary pointer event.
-					if ( touchType === 'touchstart' && !elmPepTarget.hasPrimaryTouchId ) {
-						elmPepTarget.hasPrimaryTouchId = true
-						elmPepTarget.primaryTouchId = touch.identifier
-					}
-					pointerEvent.isPrimary = (touch.identifier === elmPepTarget.primaryTouchId)
-					if ( touchType === 'touchend' && pointerEvent.isPrimary ) {
-						elmPepTarget.hasPrimaryTouchId = false
-						elmPepTarget.primaryTouchId = null
-					}
-
-					elmPepTarget.dispatchEvent( pointerEvent )
-				}
-			}
-		})
-	}
-
-	function findElmPEP ( target ) {
-		if ( document === target ) return null
-		if ( target.hasAttribute( 'elm-pep' ) ) return target
-		return findElmPEP( target.parentNode )
-	}
-
+  function findElmPEP(target) {
+    if (document === target) return null;
+    if (target.hasAttribute("elm-pep")) return target;
+    return findElmPEP(target.parentNode);
+  }
 }

--- a/elm-pep.js
+++ b/elm-pep.js
@@ -19,6 +19,9 @@ if (! ("PointerEvent" in window) ) {
 					pointerEvent.pointerId = 1
 					pointerEvent.isPrimary = true
 					elmPepTarget.dispatchEvent( pointerEvent )
+					if ( pointerEvent.defaultPrevented ) {
+						mouseEvent.preventDefault();
+					}
 				}
 			})
 		}

--- a/elm-pep.js
+++ b/elm-pep.js
@@ -56,15 +56,6 @@ if (! ("PointerEvent" in window) ) {
 					mouseEvent.offsetY = touch.clientY - rect.top
 
 					let pointerEvent = new MouseEvent( pointerType, mouseEvent )
-
-					// Safari/iOS doesn't have movement{X,Y} but elm-mouse-events expects it
-					if ( ! pointerEvent.movementX ) {
-						pointerEvent.movementX = 0
-					}
-					if ( ! pointerEvent.movementY ) {
-						pointerEvent.movementY = 0
-					}
-
 					pointerEvent.pointerId = 1 + touch.identifier
 
 					// First touch is the primary pointer event.


### PR DESCRIPTION
These changes make touch events on iOS work for me, for the example from https://github.com/mpizenberg/elm-pep/issues/4.

I don't really suggest this be merged as such, quite unsure that e.g. the `movement{X,Y}` should be set here -- looks like https://github.com/mpizenberg/elm-mouse-events needs its own polyfill there instead?

Also someone with more Javascript know-how could probably make the state-keeping nicer.