### PR TITLE
iOS fixes: offsetX/offsetY, preventDefault

### DIFF
--- a/elm-pep.js
+++ b/elm-pep.js
@@ -55,6 +55,16 @@ function addTouchToPointerListener(target, touchType, pointerType) {
       pointerEvent.offsetY = touch.clientY - rect.top;
       pointerEvent.pointerId = 1 + touch.identifier;
 
+      // Default values for standard MouseEvent fields.
+      pointerEvent.button = 0;
+      pointerEvent.buttons = 1;
+      pointerEvent.movementX = 0;
+      pointerEvent.movementY = 0;
+      pointerEvent.region = null;
+      pointerEvent.relatedTarget = null;
+      pointerEvent.x = pointerEvent.clientX;
+      pointerEvent.y = pointerEvent.clientY;
+
       // First touch is the primary pointer event.
       if (touchType === "touchstart" && primaryTouchId === null) {
         primaryTouchId = touch.identifier;

--- a/elm-pep.js
+++ b/elm-pep.js
@@ -34,27 +34,25 @@ function addMouseToPointerListener(target, mouseType, pointerType) {
 
 function addTouchToPointerListener(target, touchType, pointerType) {
   target.addEventListener(touchType, touchEvent => {
-    let mouseEvent = new CustomEvent("", { bubbles: true, cancelable: true });
-    mouseEvent.ctrlKey = touchEvent.ctrlKey;
-    mouseEvent.shiftKey = touchEvent.shiftKey;
-    mouseEvent.altKey = touchEvent.altKey;
-    mouseEvent.metaKey = touchEvent.metaKey;
-
     const changedTouches = touchEvent.changedTouches;
     const nbTouches = changedTouches.length;
     for (let t = 0; t < nbTouches; t++) {
-      const touch = changedTouches.item(t);
-      mouseEvent.clientX = touch.clientX;
-      mouseEvent.clientY = touch.clientY;
-      mouseEvent.screenX = touch.screenX;
-      mouseEvent.screenY = touch.screenY;
-      mouseEvent.pageX = touch.pageX;
-      mouseEvent.pageY = touch.pageY;
-      const rect = touch.target.getBoundingClientRect();
-      mouseEvent.offsetX = touch.clientX - rect.left;
-      mouseEvent.offsetY = touch.clientY - rect.top;
+      let pointerEvent = new CustomEvent(pointerType, { bubbles: true, cancelable: true });
+      pointerEvent.ctrlKey = touchEvent.ctrlKey;
+      pointerEvent.shiftKey = touchEvent.shiftKey;
+      pointerEvent.altKey = touchEvent.altKey;
+      pointerEvent.metaKey = touchEvent.metaKey;
 
-      let pointerEvent = new MouseEvent(pointerType, mouseEvent);
+      const touch = changedTouches.item(t);
+      pointerEvent.clientX = touch.clientX;
+      pointerEvent.clientY = touch.clientY;
+      pointerEvent.screenX = touch.screenX;
+      pointerEvent.screenY = touch.screenY;
+      pointerEvent.pageX = touch.pageX;
+      pointerEvent.pageY = touch.pageY;
+      const rect = touch.target.getBoundingClientRect();
+      pointerEvent.offsetX = touch.clientX - rect.left;
+      pointerEvent.offsetY = touch.clientY - rect.top;
       pointerEvent.pointerId = 1 + touch.identifier;
 
       // First touch is the primary pointer event.

--- a/elm-pep.js
+++ b/elm-pep.js
@@ -67,6 +67,9 @@ function addTouchToPointerListener(target, touchType, pointerType) {
       }
 
       touchEvent.target.dispatchEvent(pointerEvent);
+      if (pointerEvent.defaultPrevented) {
+        touchEvent.preventDefault();
+      }
     }
   });
 }


### PR DESCRIPTION
I've been working with elm-pointer-events on iOS some more.

These changes fix two problems for me, namely:

1. The `new MouseEvent` calculated its own wrong read-only`offsetX/offsetY` (disregarding scrolling). Changing to `CustomEvent` fixes this, but I'm not really sure of the implications.
2. In order to prevent scrolling, I had to add support for `preventDefault` like in the mouse case.

https://github.com/robx/elm-pointer-draw is a demo app that I used to test this. In the master version it exhibits both of the issues, while the branch `iosfix` uses this version of `elm-pep` and works fine for me.