### PR TITLE
minimal pointer capture for mouse events (don't merge now)

### DIFF
--- a/elm-pep.js
+++ b/elm-pep.js
@@ -11,9 +11,11 @@ let primaryTouchId = null;
 let mouseCaptureTarget = null;
 
 if (!("PointerEvent" in window)) {
+  // Define {set,release}PointerCapture
+  definePointerCapture();
+
   // Create Pointer polyfill from mouse events only on non-touch device
   if (!("TouchEvent" in window)) {
-    definePointerCapture();
     addMouseToPointerListener(document, "mousedown", "pointerdown");
     addMouseToPointerListener(document, "mousemove", "pointermove");
     addMouseToPointerListener(document, "mouseup", "pointerup");

--- a/elm-pep.js
+++ b/elm-pep.js
@@ -10,6 +10,9 @@ let primaryTouchId = null;
 // Variable to hold mouse pointer captures.
 let mouseCaptureTarget = null;
 
+// pointerId assigned to mouse-generated pointer events.
+const mousePointerId = 1;
+
 if (!("PointerEvent" in window)) {
   // Define {set,release}PointerCapture element methods
   definePointerCapture();
@@ -29,7 +32,7 @@ if (!("PointerEvent" in window)) {
 function addMouseToPointerListener(target, mouseType, pointerType) {
   target.addEventListener(mouseType, mouseEvent => {
     let pointerEvent = new MouseEvent(pointerType, mouseEvent);
-    pointerEvent.pointerId = 1;
+    pointerEvent.pointerId = mousePointerId;
     pointerEvent.isPrimary = true;
 
     let target = mouseEvent.target;
@@ -106,11 +109,17 @@ function definePointerCapture() {
     Object.defineProperties(Element.prototype, {
       'setPointerCapture': {
         value: function(pointerId) {
+          if (pointerId !== mousePointerId) {
+            return;
+          }
           mouseCaptureTarget = this;
         }
       },
       'releasePointerCapture': {
         value: function(pointerId) {
+          if (pointerId !== mousePointerId) {
+            return;
+          }
           if (mouseCaptureTarget === this) {
             mouseCaptureTarget = null;
           }

--- a/elm-pep.js
+++ b/elm-pep.js
@@ -35,6 +35,11 @@ function addMouseToPointerListener(target, mouseType, pointerType) {
     let target = mouseEvent.target;
     if (mouseCaptureTarget !== null) {
       target = mouseCaptureTarget;
+
+      // Implicit pointer release on pointerup/pointercancel.
+      if (mouseType === "mouseup") {
+        mouseCaptureTarget = null;
+      }
     }
 
     target.dispatchEvent(pointerEvent);

--- a/elm-pep.js
+++ b/elm-pep.js
@@ -27,7 +27,6 @@ if (!("PointerEvent" in window)) {
 
 // Function defining {set,release}PointerCapture from {set,releas}Capture
 function definePointerCapture() {
-  console.log("Redefining setPointerCapture");
   Element.prototype.setPointerCapture = Element.prototype.setCapture;
   Element.prototype.releasePointerCapture = Element.prototype.releaseCapture;
 }


### PR DESCRIPTION
This implements `{set,release}PointerCapture`, compare https://www.w3.org/TR/pointerevents/#widl-Element-setPointerCapture-void-long-pointerId. It doesn't make sense to merge at this point because Elm doesn't even use the methods, compare https://github.com/mpizenberg/elm-pointer-events/issues/4.

This is not a complete or necessarily a correct implementation of these methods, but enough to handle capturing `pointerup` events outside of the element that got the mouse-induced `pointerdown` event. A complete implementation would likely have to do some kind of reverse thing, where touch events are "uncaptured".